### PR TITLE
P4-1565 - Use goflow 0.77.4-1 with change urn channel fix.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o mailroom ./cmd/mailroom/main.go
 
 RUN apt update && apt install -y curl
 
-RUN export GOFLOW_VERSION=$(grep goflow go.mod | cut -d" " -f2) && \
+RUN export GOFLOW_VERSION=$(grep goflow go.mod | cut -d" " -f2 | head -n 1) && \
  curl https://codeload.github.com/nyaruka/goflow/tar.gz/$GOFLOW_VERSION | tar --wildcards --strip=1 -zx "*/docs/*"
 
 FROM alpine:3.7

--- a/go.mod
+++ b/go.mod
@@ -41,3 +41,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/nyaruka/goflow v0.77.4 => github.com/istresearch/goflow v0.77.4-1

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,7 @@ github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/gorilla/schema v1.0.2 h1:sAgNfOcNYvdDSrzGHVy9nzCQahG+qmsg+nE8dK85QRA=
 github.com/gorilla/schema v1.0.2/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
+github.com/istresearch/goflow v0.77.4-1/go.mod h1:LoRoyfHkJNVEY34AH3qDSDf7Vdq7Ztj47kNx6ceWp4I=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
Updates goflow engine to 0.77.4-1 with the change URN channel fix. 

#### Release Note
A URN's channel will be updated anytime the flow engine has an update contact->channel node. Previously it would only occur if a channel wasn't already set for a URN. 

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [x] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. Start a full engage 4.0.2 stack, using this PR's mailroom image: `istresearch/mailroom:ci-4.0.2-dev-P4-1565
`
2. Create a flow that updates a contact channel multiple times. 
3. Execute the flow and in the mailroom logs ensure you see `contact urns changed` logged for each channel change. 