### PR TITLE
P4-2678 - Engage - Voice Call Retry Disable

### DIFF
--- a/models/channel_connection.go
+++ b/models/channel_connection.go
@@ -355,7 +355,7 @@ func (c *ChannelConnection) MarkErrored(ctx context.Context, db Queryer, now tim
 	c.c.Status = ConnectionStatusErrored
 	c.c.EndedOn = &now
 
-	if c.c.RetryCount < ConnectionMaxRetries && wait >= 0{
+	if c.c.RetryCount < ConnectionMaxRetries && (wait >= time.Minute) {
 		c.c.RetryCount++
 		next := now.Add(wait)
 		c.c.NextAttempt = &next

--- a/models/channel_connection.go
+++ b/models/channel_connection.go
@@ -355,7 +355,7 @@ func (c *ChannelConnection) MarkErrored(ctx context.Context, db Queryer, now tim
 	c.c.Status = ConnectionStatusErrored
 	c.c.EndedOn = &now
 
-	if c.c.RetryCount < ConnectionMaxRetries {
+	if c.c.RetryCount < ConnectionMaxRetries && wait >= 0{
 		c.c.RetryCount++
 		next := now.Add(wait)
 		c.c.NextAttempt = &next

--- a/models/channel_connection.go
+++ b/models/channel_connection.go
@@ -355,7 +355,7 @@ func (c *ChannelConnection) MarkErrored(ctx context.Context, db Queryer, now tim
 	c.c.Status = ConnectionStatusErrored
 	c.c.EndedOn = &now
 
-	if c.c.RetryCount < ConnectionMaxRetries && (wait >= time.Minute) {
+	if c.c.RetryCount < ConnectionMaxRetries && (wait > time.Minute) {
 		c.c.RetryCount++
 		next := now.Add(wait)
 		c.c.NextAttempt = &next


### PR DESCRIPTION
# For the Reviewer
- [x] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee
UI Requires https://github.com/istresearch/rapidpro/pull/163
P4-2678 - Add option to disable IVR Flow retry

## Summary
Add option to disable IVR Flow retry

#### Release Note
Add option to disable IVR Flow retry


#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification
<img width="579" alt="Screen Shot 2021-07-20 at 1 52 40 PM" src="https://user-images.githubusercontent.com/6886738/126372960-2f1d006b-3424-42e0-8ac4-e8b15269b0c5.png">

1. Edit a flow and set Retry call if unable to connect to Never
2. Run the flow and reject the call so that it will be marked as Failed.
3. Wait to ensure that no retries are attempted.

1. Edit the same flow and set Retry to 30 minutes (Sorry, but I dont think we should add a test option for 1 minute retries!)
2. Run the flow and reject the call.
3. Wait 30 minutes to ensure that a retry is attempted.